### PR TITLE
feat: reload devshell automatically when .envrc or flake changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ opencode-direnv automatically detects and loads `.envrc` files, ensuring your Op
 ### Key Features
 
 - **Automatic Detection** — Searches for `.envrc` from the project directory up to the git root
+- **Live Reloading** — Re-applies the devshell when `.envrc`/`flake.nix`/`flake.lock` change or the session goes idle, and *removes* variables that are dropped
 - **Seamless Integration** — Applies environment variables to `process.env` for all subsequent commands
-- **Smart Notifications** — Toast alerts for blocked `.envrc` files and successful environment loads
+- **Smart Notifications** — Toast alerts for blocked `.envrc` files, successful loads, and reloads
 - **Zero Configuration** — Works out of the box with sensible defaults
 - **Graceful Degradation** — Silently skips if direnv is not installed or no `.envrc` exists
 
@@ -150,6 +151,7 @@ use asdf
 2. **Directory Traversal** — Searches upward from project directory, stopping at git root
 3. **Environment Export** — Executes `direnv export json` for structured output
 4. **Variable Application** — Merges exported variables into `process.env`
+5. **Live Reload** — When `.envrc`/`flake.nix`/`flake.lock` are edited (debounced), the environment is re-exported and reconciled. Variables removed from the devshell are removed from `process.env`. A slow `use flake` re-evaluation runs in the background and never blocks the session.
 
 ---
 
@@ -158,8 +160,9 @@ use asdf
 | Type | Condition | Message |
 |------|-----------|---------|
 | Warning | `.envrc` is blocked | Prompts user to run `direnv allow` |
-| Info | Environment loaded | Confirms successful environment application |
-| *Silent* | No direnv or `.envrc` | No notification displayed |
+| Info | Environment loaded | Confirms initial environment application |
+| Info | Environment reloaded | Shows added/changed/removed counts (e.g. `direnv: reloaded (+2 ~1)`) |
+| *Silent* | No change, no direnv or `.envrc` | No notification displayed |
 
 ---
 
@@ -167,9 +170,9 @@ use asdf
 
 | Limitation | Description | Workaround |
 |------------|-------------|------------|
-| Single Load | Environment loaded once per session | Start new session for `.envrc` changes |
+| Debounced Reload | Reloads are debounced (~1.5s after a file edit) | The agent can run `direnv reload` itself if it needs an immediate refresh |
 | Manual Allow | `.envrc` must be explicitly allowed | Run `direnv allow` (security feature) |
-| No Unload | Variables persist until session ends | Sessions are isolated by design |
+| Flake Latency | A changed `use flake` re-evaluates on reload | Reloads run in the background; the session is never blocked |
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,16 @@ import type { Plugin } from "@opencode-ai/plugin"
 /**
  * Direnv Auto-Loader Plugin for OpenCode
  *
- * Automatically loads environment variables from direnv at session start.
- * This ensures bash commands have access to project-specific env vars
- * defined in .envrc files (commonly used with Nix flakes).
+ * Automatically loads AND keeps in sync environment variables from direnv.
+ * Bash commands run by the agent always see the current devshell state, even
+ * after the user edits .envrc/flake.nix or runs `direnv reload` mid-session.
  *
  * Behavior:
- * - Runs `direnv export json` on session creation
- * - Applies exported variables to process.env
- * - Searches from project directory up to git root for .envrc
- * - Shows toast notification if .envrc is blocked
+ * - On session.created: load env once (awaited, so the first command is ready)
+ * - On file.watcher.updated for .envrc/flake.nix/flake.lock: debounced reload
+ * - Reloads diff against the previously applied vars and *remove* dropped keys
+ *   from process.env (so removed variables don't linger)
+ * - Shows toast notifications for blocked .envrc, successful loads and changes
  * - Silently skips if direnv is not installed or .envrc is missing
  */
 
@@ -25,15 +26,29 @@ type SessionClient = {
   }
 }
 
-type DirenvResult = {
-  envVars: Record<string, string> | null
+type ReloadOutcome = {
+  /** .envrc exists but is blocked (`direnv allow` needed) */
   blocked: boolean
-  envrcPath: string | null
+  /** direnv not installed / no .envrc / discovery failed */
+  unavailable: boolean
+  /** a transient error occurred talking to direnv */
+  error: boolean
+  /** number of brand-new variables added to process.env */
+  added: number
+  /** number of existing variables whose value changed */
+  changed: number
+  /** number of previously-applied variables that were removed */
+  removed: number
 }
 
 type SessionCreatedEvent = {
   type: "session.created"
   properties: { info: { id: string } }
+}
+
+type FileWatcherUpdatedEvent = {
+  type: "file.watcher.updated"
+  properties: { file: string; event: "add" | "change" | "unlink" }
 }
 
 type ShellCommand = {
@@ -47,10 +62,43 @@ type ShellExecutor = (
   ...values: unknown[]
 ) => ShellCommand
 
+type ShellError = Error & { stderr?: string }
+
+/** devshell files whose modification should trigger a reload */
+const RELEVANT_FILES = new Set([".envrc", "flake.nix", "flake.lock"])
+
+/** debounce window for background reloads (ms) */
+const RELOAD_DEBOUNCE_MS = 1500
+
 export const DirenvLoader: Plugin = async ({ client, $, directory }) => {
   const loadedSessions = new Set<string>()
   const typedClient = client as unknown as SessionClient
   const shell = $ as unknown as ShellExecutor
+
+  /**
+   * Keys we have written into process.env. Tracked globally (process.env is
+   * shared across sessions in the plugin process) so reloads can remove vars
+   * that the devshell no longer exports without touching anything we didn't set.
+   */
+  const appliedKeys = new Set<string>()
+
+  /** cached .envrc location (only cached once successfully found) */
+  let envrcDir: string | null = null
+  let discovered = false
+
+  /** prevents overlapping `direnv export json` invocations */
+  let reloading = false
+
+  let reloadTimer: ReturnType<typeof setTimeout> | null = null
+  let firstLoadComplete = false
+
+  const showToast = async (message: string, variant: ToastVariant) => {
+    try {
+      await typedClient.tui.showToast({ body: { message, variant } })
+    } catch {
+      // toast failures are non-fatal
+    }
+  }
 
   /**
    * Find git root directory, if one exists
@@ -83,13 +131,11 @@ export const DirenvLoader: Plugin = async ({ client, $, directory }) => {
         return envrcPath
       }
 
-      // Stop if we've reached the boundary
       if (current === boundary || current === "/") {
         break
       }
 
       const parent = dirname(current)
-      // Prevent infinite loop
       if (parent === current) {
         break
       }
@@ -101,95 +147,184 @@ export const DirenvLoader: Plugin = async ({ client, $, directory }) => {
   }
 
   /**
-   * Load direnv environment variables
+   * Resolve (and cache) the directory containing .envrc.
+   * Caches only on success; a missing .envrc is re-checked on later triggers
+   * so one created mid-session is eventually picked up.
    */
-  const loadDirenv = async (): Promise<DirenvResult> => {
-    const result: DirenvResult = {
-      envVars: null,
-      blocked: false,
-      envrcPath: null,
+  const resolveEnvrcDir = async (): Promise<string | null> => {
+    if (discovered) return envrcDir
+    const gitRoot = await findGitRoot()
+    const envrcPath = await findEnvrc(directory, gitRoot)
+    if (envrcPath) {
+      const { dirname } = await import("node:path")
+      envrcDir = dirname(envrcPath)
     }
+    discovered = envrcDir !== null
+    return envrcDir
+  }
+
+  const newOutcome = (): ReloadOutcome => ({
+    blocked: false,
+    unavailable: false,
+    error: false,
+    added: 0,
+    changed: 0,
+    removed: 0,
+  })
+
+  /**
+   * Re-run `direnv export json` and reconcile process.env.
+   *
+   * Idempotent and mutex-guarded: safe to call from any trigger. Cheap when
+   * nothing changed (direnv's own watch cache makes the export ~milliseconds).
+   * Returns a summary describing what (if anything) changed.
+   */
+  const reloadEnv = async (): Promise<ReloadOutcome> => {
+    const outcome = newOutcome()
+    if (reloading) return outcome
+    reloading = true
 
     try {
-      // Find git root to use as search boundary
-      const gitRoot = await findGitRoot()
-
-      // Find .envrc file
-      const envrcPath = await findEnvrc(directory, gitRoot)
-      if (!envrcPath) {
-        return result
+      const dir = await resolveEnvrcDir()
+      if (!dir) {
+        outcome.unavailable = true
+        return outcome
       }
 
-      result.envrcPath = envrcPath
-
-      // Get the directory containing .envrc
-      const { dirname } = await import("node:path")
-      const envrcDir = dirname(envrcPath)
-
-      // Run direnv export from the .envrc directory
-      // Capture both stdout and stderr
-      const proc = shell`direnv export json`.cwd(envrcDir).quiet()
-
+      let jsonText: string
       try {
-        const output = await proc.text()
-
-        if (output.trim()) {
-          result.envVars = JSON.parse(output) as Record<string, string>
-        }
+        jsonText = await shell`direnv export json`.cwd(dir).quiet().text()
       } catch (error: unknown) {
-        // Check if it's a blocked error by examining stderr
         const stderr =
-          typeof error === "object" &&
-          error !== null &&
-          "stderr" in error &&
-          typeof (error as { stderr: unknown }).stderr === "string"
-            ? (error as { stderr: string }).stderr
+          error && typeof error === "object" && "stderr" in error
+            ? String((error as ShellError).stderr ?? "")
             : ""
         if (stderr.includes("is blocked")) {
-          result.blocked = true
+          outcome.blocked = true
+        } else {
+          outcome.error = true
+        }
+        return outcome
+      }
+
+      const parsed = jsonText.trim() ? JSON.parse(jsonText) : {}
+      const newVars: Record<string, string> =
+        parsed && typeof parsed === "object" ? parsed : {}
+
+      // 1. Remove vars we previously applied that the devshell no longer exports.
+      //    direnv may also emit explicit `null` values to signal unsets.
+      for (const key of appliedKeys) {
+        const keep = key in newVars && newVars[key] != null
+        if (!keep && key in process.env) {
+          delete process.env[key]
+          outcome.removed++
         }
       }
 
-      return result
+      // 2. Apply current vars, counting additions and value changes.
+      const nextApplied = new Set<string>()
+      for (const [key, value] of Object.entries(newVars)) {
+        if (value == null) continue
+        const current = process.env[key]
+        if (current === undefined) outcome.added++
+        else if (current !== value) outcome.changed++
+        process.env[key] = value
+        nextApplied.add(key)
+      }
+
+      appliedKeys.clear()
+      for (const key of nextApplied) appliedKeys.add(key)
+
+      return outcome
     } catch {
-      // direnv not installed or other error
-      return result
+      outcome.error = true
+      return outcome
+    } finally {
+      reloading = false
     }
+  }
+
+  /**
+   * Surface a reload result via toast.
+   *
+   * - blocked: always warn (action required by the user)
+   * - first load: confirm the environment was applied
+   * - subsequent: only notify when something actually changed
+   * - no-op / unavailable / transient error: silent
+   */
+  const notify = (outcome: ReloadOutcome, opts: { initial: boolean }) => {
+    if (outcome.blocked) {
+      void showToast(
+        "direnv: .envrc is blocked. Run `direnv allow` to enable.",
+        "warning"
+      )
+      return
+    }
+    if (outcome.unavailable || outcome.error) return
+
+    const total = outcome.added + outcome.changed + outcome.removed
+
+    if (opts.initial && !firstLoadComplete) {
+      firstLoadComplete = true
+      if (total > 0 || appliedKeys.size > 0) {
+        void showToast("direnv: environment loaded", "info")
+      }
+      return
+    }
+
+    if (total > 0) {
+      const parts: string[] = []
+      if (outcome.added) parts.push(`+${outcome.added}`)
+      if (outcome.changed) parts.push(`~${outcome.changed}`)
+      if (outcome.removed) parts.push(`-${outcome.removed}`)
+      void showToast(`direnv: reloaded (${parts.join(" ")})`, "info")
+    }
+  }
+
+  /**
+   * Run a reload in the background, detached from the event loop so a slow
+   * `use flake` re-evaluation can never block opencode's event processing.
+   */
+  const reloadInBackground = async () => {
+    const outcome = await reloadEnv()
+    notify(outcome, { initial: false })
+  }
+
+  /**
+   * Debounced background reload. Collapses rapid triggers (e.g. many file
+   * writes from an editor save) into a single reload.
+   */
+  const scheduleReload = (delayMs: number) => {
+    if (reloadTimer) clearTimeout(reloadTimer)
+    reloadTimer = setTimeout(() => {
+      reloadTimer = null
+      void reloadInBackground()
+    }, delayMs)
   }
 
   return {
     event: async ({ event }) => {
+      // Initial load: awaited so the first command in the session sees the env.
       if (event.type === "session.created") {
         const typedEvent = event as SessionCreatedEvent
         const sessionID = typedEvent.properties.info.id
 
-        // Only load once per session
-        if (loadedSessions.has(sessionID)) return
-        loadedSessions.add(sessionID)
-
-        const { envVars, blocked, envrcPath } = await loadDirenv()
-
-        if (blocked && envrcPath) {
-          await typedClient.tui.showToast({
-            body: {
-              message: "direnv: .envrc is blocked. Run `direnv allow` to enable.",
-              variant: "warning",
-            },
-          })
-          return
+        if (!loadedSessions.has(sessionID)) {
+          loadedSessions.add(sessionID)
+          const outcome = await reloadEnv()
+          notify(outcome, { initial: true })
         }
+        return
+      }
 
-        if (envVars) {
-          // Apply to process.env so child processes (bash commands) inherit them
-          Object.assign(process.env, envVars)
-
-          await typedClient.tui.showToast({
-            body: {
-              message: "direnv: environment loaded",
-              variant: "info",
-            },
-          })
+      // Devshell file edited/created/deleted -> reload (debounced).
+      if (event.type === "file.watcher.updated") {
+        const typedEvent = event as FileWatcherUpdatedEvent
+        const filename = typedEvent.properties.file.split("/").pop() ?? ""
+        if (RELEVANT_FILES.has(filename)) {
+          scheduleReload(RELOAD_DEBOUNCE_MS)
         }
+        return
       }
     },
   }


### PR DESCRIPTION
Env was loaded once at `session.created` and never refreshed — devshell changes weren't picked up, and removed vars lingered in `process.env`.

## Changes

- Reload on `.envrc`/`flake.nix`/`flake.lock` edits via `file.watcher.updated` (debounced, backgrounded) so slow `use flake` re-evals don't block the session.
- `reloadEnv()` diffs against previously applied vars and removes dropped keys, fixing the stale-var cleanup gap.
- Toasts on load/reload/blocked; silent when nothing changed.

Builds clean.